### PR TITLE
update user-guide: new URL parameter of Vivliostyle Viewer

### DIFF
--- a/ja/user-guide.md
+++ b/ja/user-guide.md
@@ -45,35 +45,35 @@ Vivliostyle Viewer をローカル環境で利用する場合は、配布パッ�
 
 オンラインで公開されている [vivliostyle.org/viewer/](https://vivliostyle.org/viewer/) も利用でき、これは常に最新のリリース版に更新されています。いち早く最新のバージョンを試したい場合は、[vivliostyle.now.sh](https://vivliostyle.now.sh)を利用してください。
 
-パラメータを指定しないで <Link v-bind:isOnline="isOnline" path="/viewer">Vivliostyle Viewer</Link> を開くと、文書URLの入力欄（“Input a document URL”）と次のように使い方の説明が表示されます:
+パラメータを指定しないで <Link v-bind:isOnline="isOnline" path="/viewer/">Vivliostyle Viewer</Link> を開くと、文書URLの入力欄 (“Input a document URL”)、 **Book Mode** と **Render All Pages** のチェックボックス、および使い方のヘルプが表示されます。
 
-Access to <Link v-bind:isOnline="isOnline" path="/viewer/#x=./samples.html" />.
+試してみる: <Link v-bind:isOnline="isOnline" path="/viewer/" />
 
 ## サポートされている文書の種類
 
-- (X)HTML文書＋ページメディア用のCSS
-- Web出版物（複数のHTML文書からなるコレクション）: プライマリーエントリーページまたはマニフェストファイルのURLを指定します。
-- ZIP解凍済みのEPUB: OPFファイルのURLまたは解凍されたEPUBファイルのトップディレクトリを指定します。
+- HTML文書＋ページメディア用のCSS
+- 本のような出版物（目次付き） (**Book Mode**: オン)
+  - Web出版物（複数のHTML文書からなるコレクション）: 最初のHTMLまたはマニフェストファイルのURLを指定します。
+  - ZIP解凍済みのEPUB: OPFファイルのURLまたは解凍されたEPUBファイルのトップディレクトリを指定します。
 
 ### URLパラメータのオプション
 
-- `#b=(document URL)` or `#x=&(document URL)`
+- #**src**=&lt;document URL>
+- &amp;**bookMode**=[**true** | **false**] (**Book Mode**)
+  - **true**: 本のような出版物（目次付き）用
+    - HTML文書のURLが指定された場合、その出版物マニフェストまたは目次（<nav role="doc-toc"> などでマークアップ）からリンクされた一連のHTML文書が自動的に読み込まれます。
+  - **false** (デフォルト): 単体のHTML文書用
+- &amp;**renderAllPages**=[**true** | **false**] (**Render All Pages**)
+  - **true** (デフォルト): 印刷用（すべてのページが印刷可能で、ページ番号は期待されるとおりに機能します）
+  - **false**: 閲覧用（おおまかなページ番号を使って、クイックロード）
+- &amp;**spread**=[**true** | **false** | **auto**] (**Page Spread View**)
+  - **true**: 見開き表示
+  - **false**: 単一ページ表示
+  - **auto** (デフォルト): 自動見開き表示
+- &amp;**style**=&lt;追加の外部スタイルシートのURL>
+- &amp;**userStyle**=&lt;ユーザースタイルシートのURL>
 
-  - #**b**= Book view. When (X)HTML document URL is specified, the URL is treated as primary entry page’s, and a series of HTML documents linked from the manifest or TOC (Table of Contents, e.g. marked up with `<nav role="doc-toc">`) are automatically loaded.
-  - #**x**= (X)HTML document is simply loaded. Multiple documents can be specified as `#x=(1st HTML)&x=(2nd HTML)...`
-
-- `&spread=[true | false | auto]`
-  - true: Spread view
-  - false: Single page view
-  - auto: Auto spread view (default)
-- &amp;renderAllPages=[true |false]
-  - true: for Print (all pages printable, page count works as
-    expected)
-  - false: for Read (quick loading with rough page count)
-- &amp;style=&lt;additional external style sheet URL&gt;
-- &amp;userStyle=&lt;user style sheet URL&gt;
-
-Options can also be set in the **Settings** panel.
+オプションは設定パネル（**Settings**）でも設定できます。
 
 ### 留意点
 
@@ -88,7 +88,7 @@ Options can also be set in the **Settings** panel.
 HTMLファイルを Vivliostyle Viewer で表示するには、Webサーバーが読み込める場所（上記手順にしたがってWebサーバーを起動している場合は、配布パッケージを解凍してできたフォルダ内）にそのファイル（およびそのファイルから読み込まれるCSSや画像ファイル）を置いた上で、次のようにパラメータを付加したURLをブラウザで開きます:
 
 ```
-⟨Vivliostyle ViewerのURL⟩#x=⟨表示するファイルのURL (Vivliostyle Viewerからの相対)⟩
+⟨Vivliostyle ViewerのURL⟩#src=⟨表示するファイルのURL (Vivliostyle Viewerからの相対)⟩
 ```
 
 注: Vivliostyle Viewer 本体とは別ドメインの文書を読み込もうとする場合、文書があるWebサーバーの設定によって、文書が読み込めない場合があります。文書を読み込ませるためには、サーバー側で CORS (Cross-Origin Resource Sharing)の設定が必要です。
@@ -97,57 +97,31 @@ HTMLファイルを Vivliostyle Viewer で表示するには、Webサーバー�
 
 例: HTMLファイル [samples/gon/index.html](https://vivliostyle.github.io/vivliostyle_doc/samples/gon/index.html) を表示する場合:
 
-<Link v-bind:isOnline="isOnline" path="/viewer/#x=../samples/gon/index.html" />
-
-テキストボックスに文書ファイルのパス（または URL）を入力すると、その文書を表示する Vivliostyle Viewer のURLを下に表示します:
-
-<input
-  id="file-path-input"
-  type="text"
-  defaultValue="/samples/gon/index.html"
-  size="30"
-/>
-
-<Link v-bind:isOnline="isOnline" path="/viewer/#x=../samples/gon/index.html" />
+<Link v-bind:isOnline="isOnline" path="/viewer/#src=../samples/gon/index.html" />
 
 ### EPUB
 
 Vivliostyle ViewerではZIP解凍済みのEPUBファイルを表示することができます。この場合、次のパラメータを指定します:
 
 ```
-#b=⟨表示する解凍済みEPUBフォルダのURL (Vivliostyle Viewer からの相対)⟩
+#src=⟨表示する解凍済みEPUBフォルダのURL⟩&bookMode=true
 ```
-
-例: [samples/niimi/](https://vivliostyle.github.io/vivliostyle_doc/samples/niimi/index.html) フォルダに解凍済みのEPUBファイルを表示する場合:
-
-<Link v-bind:isOnline="isOnline" path="/viewer/#b=../samples/niimi/" />
-
-テキストボックスにEPUBフォルダのパス（またはURL）を入力すると、その文書を表示するVivliostyle ViewerのURLを下に表示します:
-
-<input
-  id="epub-path-input"
-  type="text"
-  defaultValue="/samples/niimi/"
-  size="30"
-/>
-
-<Link v-bind:isOnline="isOnline" path="/viewer/#b=../samples/niimi/" />
 
 GitHub上に公開されているZIP解凍済みのEPUBファイルを表示する例:
 
 - [IDPF/epub3-samples](https://github.com/IDPF/epub3-samples/)の 『[Accessible EPUB 3](https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/)』
 
-  <Link v-bind:isOnline="isOnline" path="/viewer/#b=https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/" />
+  <Link v-bind:isOnline="isOnline" path="/viewer/#src=https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/&bookMode=true" />
 
 ### Web出版物
 
 Vivliostyle ViewerではWeb出版物（複数のHTML文書からなるコレクション）を表示することができます。この場合、次のパラメータを指定します:
 
 ```
-#b=⟨プライマリーエントリーページのHTML文書またはマニフェストファイルのURL (Vivliostyle Viewer からの相対)⟩
+#src=⟨最初のHTML文書またはマニフェストファイルのURL⟩&bookMode=true
 ```
 
-Web出版物のマニフェストの形式については、W3Cドラフトの [Web Publications](https://w3c.github.io/wpub/) および [Readium Web Publication Manifest](https://github.com/readium/webpub-manifest/) をサポートしています。
+Web出版物のマニフェストの形式については、W3Cドラフトの [Publication Manifest](https://www.w3.org/TR/pub-manifest/) および [Readium Web Publication Manifest](https://github.com/readium/webpub-manifest/) をサポートしています。
 
 Web出版物のマニフェストが存在しなくても、指定したHTML文書内の目次要素内に他のHTML文書へのリンクがある場合は、それらの文書が自動的にロードされます。Vivliostyle はHTML文書内の次のCSSセレクタにマッチする要素を目次要素として扱います:
 `[role=doc-toc], [role=directory], nav li, .toc, #toc`
@@ -156,7 +130,7 @@ Web上に公開されている複数のHTML文書からなる出版物を表示�
 
 - [CSS Working Group Editor Drafts](https://drafts.csswg.org/) の 『[Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification](https://drafts.csswg.org/css2/)』
 
-  <Link v-bind:isOnline="isOnline" path="/viewer/#b=https://drafts.csswg.org/css2/" />
+  <Link v-bind:isOnline="isOnline" path="/viewer/#src=https://drafts.csswg.org/css2/&bookMode=true" />
 
 ## 詳細な設定
 
@@ -208,12 +182,12 @@ Web上に公開されている文書に、設定パネルからユーザース�
 
 - [CSS Working Group Editor Drafts](https://drafts.csswg.org/) の 『[Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification](https://drafts.csswg.org/css2/)』
 
-  <Link v-bind:isOnline="isOnline" path="/viewer/#b=https://drafts.csswg.org/css2/&userStyle=data:,/*%3Cviewer%3E*/%0A@page%20%7B%20size:%20A4;%20%7D%0A/*%3C/viewer%3E*/%0A%0A@page%20:first%20%7B%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%7D%0A%0A@page%20:left%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20env(pub-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D%0A%0A@page%20:right%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20env(doc-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D&renderAllPages=true">
-    #b=https://drafts.csswg.org/css2/&userStyle=data:,CSS
+  <Link v-bind:isOnline="isOnline" path="/viewer/#src=https://drafts.csswg.org/css2/&bookMode=true&userStyle=data:,/*%3Cviewer%3E*/%0A@page%20%7B%20size:%20A4;%20%7D%0A/*%3C/viewer%3E*/%0A%0A@page%20:first%20%7B%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%7D%0A%0A@page%20:left%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20env(pub-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D%0A%0A@page%20:right%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20env(doc-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D">
+    #src=https://drafts.csswg.org/css2/&bookMode=true&userStyle=data:,CSS
   </AdaptiveLink>
 
 ```
-#b=(URL)&renderAllPages=true&userStyle=data:,/*<viewer>*/
+#src=(URL)&bookMode=true&userStyle=data:,/*<viewer>*/
 @page { size: A4; }
 /*</viewer>*/
 

--- a/user-guide.md
+++ b/user-guide.md
@@ -49,33 +49,33 @@ attached to the distribution package.
 
 You can also use the public online Vivliostyle Viewer ([vivliostyle.org/viewer/](https://vivliostyle.org/viewer/)) that has always been updated to the latest release version. For early bird users, there is also canary version available [vivliostyle.now.sh](https://vivliostyle.now.sh).
 
-When you open <Link v-bind:isOnline="isOnline" path="/viewer">Vivliostyle Viewer</Link> without specifying parameters, an “Input a document URL” box and the following usage description is displayed:
+When you open <Link v-bind:isOnline="isOnline" path="/viewer/">Vivliostyle Viewer</Link> without specifying parameters, an “Input a document URL” box, **Book Mode** and **Render All Pages** check boxes, and usage help is displayed.
 
-Access to <Link v-bind:isOnline="isOnline" path="/viewer/#x=./samples.html" />.
+Access to <Link v-bind:isOnline="isOnline" path="/viewer/" />.
 
 ## Supported document types
 
-- (X)HTML document, with CSS for paged media
-  - Web publication (a collection of HTML documents): specify URL of the primary entry page or manifest file.
+- HTML documents, with CSS for paged media
+- Book-like publications, with Table of Contents (**Book Mode**: On)
+  - Web publications (a collection of HTML documents): specify URL of the first HTML or the manifest file.
   - Unzipped EPUB: specify URL of OPF file or top directory of the unzipped EPUB files.
 
 ### URL parameter options
 
-- `#b=(document URL)` or `#x=&(document URL)`
-
-  - #**b**= Book view. When (X)HTML document URL is specified, the URL is treated as primary entry page’s, and a series of HTML documents linked from the manifest or TOC (Table of Contents, e.g. marked up with `<nav role="doc-toc">`) are automatically loaded.
-  - #**x**= (X)HTML document is simply loaded. Multiple documents can be specified as `#x=(1st HTML)&x=(2nd HTML)...`
-
-- `&spread=[true | false | auto]`
-  - true: Spread view
-  - false: Single page view
-  - auto: Auto spread view (default)
-- &amp;renderAllPages=[true |false]
-  - true: for Print (all pages printable, page count works as
-    expected)
-  - false: for Read (quick loading with rough page count)
-- &amp;style=&lt;additional external style sheet URL&gt;
-- &amp;userStyle=&lt;user style sheet URL&gt;
+- #**src**=&lt;document URL>
+- &amp;**bookMode**=[**true** | **false**] (**Book Mode**)
+  - **true**: for Book-like publications, with Table of Contents.
+    - When an HTML document URL is specified, a series of HTML documents linked from the publication manifest or Table of Contents (e.g., marked up with `<nav role="doc-toc">`) are automatically loaded.
+  - **false** (default): for single HTML documents
+- &amp;**renderAllPages**=[**true** | **false**] (**Render All Pages**)
+  - **true** (default): for Print (all pages printable, page count works as expected)
+  - **false**: for Read (quick loading with rough page count)
+- &amp;**spread**=[**true** | **false** | **auto**] (**Page Spread View**)
+  - **true**: Spread view
+  - **false**: Single page view
+  - **auto** (default): Auto spread view
+- &amp;**style**=&lt;additional external style sheet URL>
+- &amp;**userStyle**=&lt;user style sheet URL>
 
 Options can also be set in the **Settings** panel.
 
@@ -115,18 +115,7 @@ connection is required when the document contains mathematics.
 
 Example: If you want to display a HTML file [samples/wood/index.html](https://vivliostyle.github.io/vivliostyle_doc/samples/wood/index.html):
 
-<Link v-bind:isOnline="isOnline" path="/viewer/#x=../samples/wood/index.html" />
-
-Input the document file path (or URL) in the text box; the Vivliostyle Viewer URL of the document is displayed below:
-
-<input
-  id="file-path-input"
-  type="text"
-  defaultValue="/samples/wood/index.html"
-  size="30"
-/>
-
-<Link v-bind:isOnline="isOnline" path="/viewer/#x=../samples/wood/index.html" />
+<Link v-bind:isOnline="isOnline" path="/viewer/#src=../samples/wood/index.html" />
 
 ### EPUB
 
@@ -135,29 +124,14 @@ You can display unzipped EPUB files with the Vivliostyle Viewer.
 In this case, use the following parameter:
 
 ```
-#b=⟨URL of the unzipped EPUB folder (relative to the Vivliostyle Viewer)⟩
+#src=⟨URL of the unzipped EPUB folder⟩&bookMode=true
 ```
-
-Example: If you want to display an unzipped EPUB folder [samples/niimi/](https://vivliostyle.github.io/vivliostyle_doc/samples/niimi/index.html):
-
-<Link v-bind:isOnline="isOnline" path="/viewer/#b=../samples/niimi/" />
-
-Input the EPUB folder path (or URL) in the text box; the Vivliostyle Viewer URL of the EPUB document is displayed below:
-
-<input
-  id="epub-path-input"
-  type="text"
-  defaultValue="/samples/niimi/"
-  size="30"
-/>
-
-<Link v-bind:isOnline="isOnline" path="/viewer/#b=../samples/niimi/" />
 
 An example of displaying unzipped EPUB on GitHub:
 
 - [Accessible EPUB 3](https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/) on [IDPF/epub3-samples](https://github.com/IDPF/epub3-samples/)
 
-  <Link v-bind:isOnline="isOnline" path="/viewer/#b=https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/" />
+  <Link v-bind:isOnline="isOnline" path="/viewer/#src=https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/&bookMode=true" />
 
 ### Web publications
 
@@ -166,10 +140,10 @@ with the Vivliostyle Viewer. In this case, use the following
 parameter:
 
 ```
-#b=⟨URL of the primary entry page HTML document or manifest file (relative to the Vivliostyle Viewer)⟩
+#src=⟨URL of the first HTML document or manifest file⟩&bookMode=true
 ```
 
-For the format of Web publication manifest, W3C draft [Web Publications](https://w3c.github.io/wpub/) and [Readium Web Publication Manifest](https://github.com/readium/webpub-manifest/) are supported.
+For the format of Web publication manifest, W3C draft [Publication Manifest](https://www.w3.org/TR/pub-manifest/) and [Readium Web Publication Manifest](https://github.com/readium/webpub-manifest/) are supported.
 
 When Web publication manifest does not exist, and there are links
 to other HTML documents in the table of contents in the specified
@@ -182,7 +156,8 @@ An example of displaying publications composed of multiple HTML
 documents published on the Web:
 
 - [Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification](https://drafts.csswg.org/css2/) on [CSS Working Group Editor Drafts](https://drafts.csswg.org/)
-  <Link v-bind:isOnline="isOnline" path="/viewer/#b=https://drafts.csswg.org/css2/" />
+
+  <Link v-bind:isOnline="isOnline" path="/viewer/#src=https://drafts.csswg.org/css2/&bookMode=true" />
 
 ## Fine-grained config
 
@@ -252,12 +227,12 @@ the document on the Web:
 - [Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification](https://drafts.csswg.org/css2/) on
   [CSS Working Group Editor Drafts](https://drafts.csswg.org/)
 
-  <Link v-bind:isOnline="isOnline" path="/viewer/#b=https://drafts.csswg.org/css2/&userStyle=data:,/*%3Cviewer%3E*/%0A@page%20%7B%20size:%20A4;%20%7D%0A/*%3C/viewer%3E*/%0A%0A@page%20:first%20%7B%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%7D%0A%0A@page%20:left%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20env(pub-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D%0A%0A@page%20:right%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20env(doc-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D&renderAllPages=true">
-    #b=https://drafts.csswg.org/css2/&userStyle=data:,CSS
+  <Link v-bind:isOnline="isOnline" path="/viewer/#src=https://drafts.csswg.org/css2/&bookMode=true&userStyle=data:,/*%3Cviewer%3E*/%0A@page%20%7B%20size:%20A4;%20%7D%0A/*%3C/viewer%3E*/%0A%0A@page%20:first%20%7B%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20none;%0A%20%20%7D%0A%7D%0A%0A@page%20:left%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-left%20%7B%0A%20%20%20%20content:%20env(pub-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D%0A%0A@page%20:right%20%7B%0A%20%20font-size:%200.8rem;%0A%20%20@top-right%20%7B%0A%20%20%20%20content:%20env(doc-title);%0A%20%20%7D%0A%20%20@bottom-center%20%7B%0A%20%20%20%20content:%20counter(page);%0A%20%20%7D%0A%7D">
+    #src=https://drafts.csswg.org/css2/&bookMode=true&userStyle=data:,CSS
   </AdaptiveLink>
 
 ```
-#b=(URL)&renderAllPages=true&userStyle=data:,/*<viewer>*/
+#src=(URL)&bookMode=true&userStyle=data:,/*<viewer>*/
 @page { size: A4; }
 /*</viewer>*/
 


### PR DESCRIPTION
- new URL parameter of Vivliostyle Viewer
- remove examples with textbox URL input
- remove the EPUB example "niimi" because this sample is not a valid EPUB and not good as an example