### PR TITLE
Replace links of DESIGN.md with theme document page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@
 - [Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli/blob/main/README.md#readme)
 - [Create Book](https://github.com/vivliostyle/create-book#readme)
 - [VFM](https://vivliostyle.github.io/vfm/#/vfm)
-- [Vivliostyle Themes](https://github.com/vivliostyle/themes#readme)
-- [Theme Design Guideline](https://github.com/vivliostyle/themes/tree/master/DESIGN.md#readme)
+- [Vivliostyle Themes](https://vivliostyle.github.io/themes/#/)
 
 ## Releases
 

--- a/create-book.md
+++ b/create-book.md
@@ -218,7 +218,7 @@ theme: 'sample.css',
 ```
 A theme package contains a CSS file that defines the style of the book. Please refer to A specification below.
 
-- [Theme Design Guideline (Draft)](https://github.com/vivliostyle/themes/blob/master/DESIGN.md)
+- [Spec of Theme](https://vivliostyle.github.io/themes/#/spec)
 
 The theme package can be obtained from the following.
 

--- a/index.html
+++ b/index.html
@@ -81,12 +81,7 @@
               },
               {
                 title: '💅 Vivliostyle Themes',
-                link: 'https://github.com/vivliostyle/themes#readme',
-              },
-              {
-                title: '🦮 Theme Design Guideline',
-                link:
-                  'https://github.com/vivliostyle/themes/tree/master/DESIGN.md#readme',
+                link: 'https://vivliostyle.github.io/themes/#/',
               },
             ],
           },
@@ -175,12 +170,7 @@
                   },
                   {
                     title: '💅 Vivliostyle Themes',
-                    link: 'https://github.com/vivliostyle/themes#readme',
-                  },
-                  {
-                    title: '🦮 Theme Design Guideline',
-                    link:
-                      'https://github.com/vivliostyle/themes/tree/master/DESIGN.md#readme',
+                    link: 'https://vivliostyle.github.io/themes/#/ja/',
                   },
                 ],
               },

--- a/ja/README.md
+++ b/ja/README.md
@@ -20,8 +20,7 @@
 - [Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli/blob/main/README.md#readme)
 - [Create Book](https://github.com/vivliostyle/create-book#readme)
 - [VFM](https://vivliostyle.github.io/vfm/#/vfm)
-- [Vivliostyle Themes](https://github.com/vivliostyle/themes#readme)
-- [Theme Design Guideline](https://github.com/vivliostyle/themes/tree/master/DESIGN.md#readme)
+- [Vivliostyle Themes](https://vivliostyle.github.io/themes/#/ja/)
 
 ## リリース
 

--- a/ja/create-book.md
+++ b/ja/create-book.md
@@ -222,7 +222,7 @@ theme: 'sample.css',
 
 テーマパッケージは本のスタイルを定義したCSSファイルを含みます。仕様は下記を参照してください。
 
-- [Theme Design Guideline (Draft)](https://github.com/vivliostyle/themes/blob/master/DESIGN.md)
+- [Theme の仕様](https://vivliostyle.github.io/themes/#/ja/spec)
 
 なお、テーマパッケージは下記から取得できます。
 


### PR DESCRIPTION
resolved #17 .

DESIGN.md の内容はすべて新しいドキュメントページ https://vivliostyle.github.io/themes/#/spec に移動させて、DESIGN.md は削除されています。DESIGN.md へのリンクは新しいドキュメントページへのリンクに差し替えました。